### PR TITLE
Fixed deleting backups in local destinations

### DIFF
--- a/destinations/local/init.php
+++ b/destinations/local/init.php
@@ -152,7 +152,7 @@ class pb_backupbuddy_destination_local {
 
 		$remote_files = self::listFiles( $settings );
 
-		if ( count( $remote_files ) >= $limit ) {
+		if ( count( $remote_files ) <= $limit ) {
 			pb_backupbuddy::status( 'details', 'Archives count (' . count( $remote_files ) . ') fewer or equal to limit (' . $limit . '). Trimming unnecessary.' );
 			return false;
 		}


### PR DESCRIPTION
Hello,

this PR is intended to fix the problem that backups on local destinations are not deleted even though the number of archives exceeds the number in the settings.

Regards
Maven85