### PR TITLE
Fixed deleting backups in local destinations - part2

### DIFF
--- a/destinations/local/init.php
+++ b/destinations/local/init.php
@@ -493,15 +493,14 @@ class pb_backupbuddy_destination_local {
 		}
 
 		foreach ( $files as $file ) {
-			$full_path = $settings['path'] . $file;
-			if ( ! file_exists( $full_path ) ) {
+			if ( ! file_exists( $file ) ) {
 				pb_backupbuddy::status( 'details', __( 'Attempt to delete Local destination file `' . $file . '` failed: File not found.', 'it-l10n-backupbuddy' ) );
 				return false;
 			}
 
-			@unlink( $full_path );
+			@unlink( $file );
 
-			if ( file_exists( $full_path ) ) {
+			if ( file_exists( $file ) ) {
 				pb_backupbuddy::status( 'error', __( 'Attempt to delete Local destination file `' . $file . '` failed: Unlink unsuccessful.', 'it-l10n-backupbuddy' ) );
 				return false;
 			}


### PR DESCRIPTION
Hello, here is the next part to solve the problem that backups are not deleted in local destinations.

Currently the backups are not deleted because the files cannot be found.

The reason is that the full path is created again in `delete`, although this has already been defined in `get_files` by `$files = glob( $settings['path'] . $filter );` is delivered.

Regards
Maven85